### PR TITLE
Fix noninteractive apt installs

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -51,8 +51,6 @@ jobs:
       - name: Extract server release
         run: mkdir server && cd server && 7z x ../server.7z && cd ..
 
-      - name: Download winehq key file
-        run: wget https://dl.winehq.org/wine-builds/winehq.key
 
       # Install the cosign tool except on PR
       # https://github.com/sigstore/cosign-installer


### PR DESCRIPTION
## Summary
- avoid interactive prompts during apt operations by setting `DEBIAN_FRONTEND=noninteractive`
- use `apt-get` instead of `apt` for scripting
- update to Ubuntu 25.04 and refresh WineHQ install steps
- fix runtime environment variables in entrypoint and drop unused key download step
- use official keyring instructions and exec entrypoint

## Testing
- `pip install pyyaml`


------
https://chatgpt.com/codex/tasks/task_e_68502cd1532083288f591878a9fe92fe